### PR TITLE
updated reference link to config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ This repository contains a number of [Jupyter Notebooks][jupyter] that give a pr
 > **Note**  
 > Changing these configurations is only necessary when you run your own CSE and Notification Server instead the one provided with the notebooks.
 
-Please change the configuration in the file [config.py](config.py) according to your setup.
+Please change the configuration in the file [config.py](src/config.py) according to your setup.
 
 #### CSE Configuration
 - **cseRN** : The resource name of the CSE.


### PR DESCRIPTION
Reference to the config file in the readme redirects to an error 404 GitHub page as the config file location is different. Hence made this small change to refer to the config.py file inside the src directory.
[ps: first open source contribution]
